### PR TITLE
CRUD de Actividades terminado, ahora si.

### DIFF
--- a/app.py
+++ b/app.py
@@ -7,6 +7,7 @@ from dotenv import load_dotenv
 from config import *
 from src.db import Database
 from src.controllers import *
+from src.utils.custom_json_provider import CustomJSONProvider
 from src.utils.jwt_config import init_jwt
 from src.utils.error_handlers import register_error_handlers
 from src.controllers.auth_controller import auth_routes_bp
@@ -21,6 +22,9 @@ load_dotenv()
 def create_app():
     """Application factory function."""
     app = Flask(__name__)
+
+    app.json = CustomJSONProvider(app)
+
     # Enable CORS for all domains
     CORS(
         app,

--- a/src/controllers/activity_controller.py
+++ b/src/controllers/activity_controller.py
@@ -47,10 +47,10 @@ def create_activity():
     claims = get_jwt()
     if claims["role"] != "professor":
         abort(403)
-    activity = Activity(name=request.form.get("name"),
-                        description=request.form.get("description"),
-                        due_date=request.form.get("due_date"),
-                        min_grade=request.form.get("min_grade"),
+    activity = Activity(name=request.json.get("name"),
+                        description=request.json.get("description"),
+                        due_date=request.json.get("due_date"),
+                        min_grade=request.json.get("min_grade"),
                         professor_id=claims["professor_id"])
     try:
         activity = ActivityService(app.db).create(activity)
@@ -76,10 +76,10 @@ def update_activity(activity_id: int):
     if claims["role"] != "professor":
         abort(403)
     activity = Activity(id=activity_id,
-                        name=request.form.get("name"),
-                        description=request.form.get("description"),
-                        due_date=request.form.get("due_date"),
-                        min_grade=request.form.get("min_grade"),
+                        name=request.json.get("name"),
+                        description=request.json.get("description"),
+                        due_date=request.json.get("due_date"),
+                        min_grade=request.json.get("min_grade"),
                         professor_id=claims["professor_id"])
     try:
         activity = ActivityService(app.db).update(activity)

--- a/src/controllers/activity_controller.py
+++ b/src/controllers/activity_controller.py
@@ -1,27 +1,29 @@
-from datetime import datetime
-
 from flask import request
 from flask import current_app as app
 from flask import jsonify
 from flask import abort
 from flask import Blueprint
+from flask_jwt_extended import jwt_required, get_jwt
+from mysql.connector.errors import Error, IntegrityError, DataError
 
 from src.models.activity import Activity
+from src.services.activity_service import ActivityService, ActivityOwnerError
 from src.repositories.activity_repository import ActivityRepository
-from mysql.connector.errors import IntegrityError
 
 activity_routes_bp = Blueprint('activity_bp', __name__, url_prefix="/api/activities")
 
 @activity_routes_bp.route("/", methods=["GET"])
+@jwt_required()
 def get_activities():
-    professor_id = request.args.get("professor_id", '')
-    if professor_id:
-        print("get_activities_by_professor -> ?professor_id: ", professor_id)
-        user_repository = ActivityRepository(app.db)
-        activities = user_repository.find_by_professor(professor_id)
+    claims = get_jwt()
+    role = claims["role"]
+    activity_service = ActivityService(app.db)
+    if role == "student":
+        professor_id = request.args.get("professor_id")
     else:
-        user_repository = ActivityRepository(app.db)
-        activities = user_repository.find_all()
+        professor_id = claims["professor_id"]
+    activities = activity_service.get_activities(professor_id)
+
     if activities:
         return jsonify(activities), 200
     else:
@@ -29,29 +31,89 @@ def get_activities():
 
 @activity_routes_bp.route("/<int:activity_id>", methods=["GET"])
 def get_activity(activity_id: int):
-    user_repository = ActivityRepository(app.db)
-    activity = user_repository.find_by_id(activity_id)
+    """DEPRECATED. nadie me usa :("""
+    app.logger.warning("Deprecation warning: get_activity. This endpoint might go away in the future.")
+    activity= ActivityRepository(app.db).find_by_id(activity_id)
     if activity.id:
-        return jsonify(activity.__dict__), 200
+        response = {"Deprecation warning": "This endpoint might go away in the future."}
+        response.update(activity.__dict__)
+        return jsonify(response), 200
     else:
         abort(404)
 
 @activity_routes_bp.route("/", methods=["POST"])
+@jwt_required()
 def create_activity():
-    activity_to_register = Activity(
-        name=request.form.get("name", ''),
-        description=request.form.get("description", ''),
-        due_date=datetime.strptime(request.form.get("due_date", ''), "%Y-%m-%d %H:%M:%S.%f"),
-        min_grade=request.form.get("min_grade", ''),
-        professor_id=request.form.get("professor_id", '')
-    )
+    claims = get_jwt()
+    if claims["role"] != "professor":
+        abort(403)
+    activity = Activity(name=request.form.get("name"),
+                        description=request.form.get("description"),
+                        due_date=request.form.get("due_date"),
+                        min_grade=request.form.get("min_grade"),
+                        professor_id=claims["professor_id"])
     try:
-        activity = ActivityRepository(app.db).save(activity_to_register)
-    except IntegrityError:
-        # fk de professor_id debe ser erronea
+        activity = ActivityService(app.db).create(activity)
+    except ValueError as err:
+        return jsonify({"message": f"Value error: {err}"}), 422
+    except DataError as err:
+        return jsonify({"message": "Wrong size/format data."}), 422
+    except IntegrityError as err:
+        return jsonify({"message": "Bad professor id."}), 422
+    except Error as err:
+        app.logger.error("MySQL error. %s - %s", err.errno, err.msg)
         abort(500)
     else:
         if activity.id:
-            return jsonify({"message": f"Activity {activity.name} successfully saved"}), 200
+            return jsonify(activity.__dict__), 200
         else:
             abort(500)
+
+@activity_routes_bp.route("/<int:activity_id>", methods=["PATCH"])
+@jwt_required()
+def update_activity(activity_id: int):
+    claims = get_jwt()
+    if claims["role"] != "professor":
+        abort(403)
+    activity = Activity(id=activity_id,
+                        name=request.form.get("name"),
+                        description=request.form.get("description"),
+                        due_date=request.form.get("due_date"),
+                        min_grade=request.form.get("min_grade"),
+                        professor_id=claims["professor_id"])
+    try:
+        activity = ActivityService(app.db).update(activity)
+    except ActivityOwnerError as err:
+        return jsonify({"message": f"{err}"}), 403
+    except ValueError as err:
+        return jsonify({"message": f"Value error: {err}"}), 422
+    except IntegrityError:
+        return jsonify({"message": "Bad professor id."}), 422
+    except DataError as err:
+        return jsonify({"message": "Wrong size/format data."}), 422
+    except Error as err:
+        app.logger.error("MySQL error. %s - %s", err.errno, err.msg)
+        abort(500)
+    else:
+        if activity.id is None:
+            abort(404)
+        else:
+            return jsonify(activity.__dict__), 200
+
+@activity_routes_bp.route("/<int:activity_id>", methods=["DELETE"])
+@jwt_required()
+def delete_activity(activity_id):
+    claims = get_jwt()
+    if claims["role"] != "professor":
+        abort(403)
+    try:
+        ActivityService(app.db).delete(activity_id, claims["professor_id"])
+    except ValueError as err:
+        return jsonify({"message": f"Value error. {err}"}), 422
+    except ActivityOwnerError as err:
+        return jsonify({"message": f"Unable to delete. {err}"}), 403
+    except Error as err:
+        app.logger.error("MySQL error. %s - %s", err.errno, err.msg)
+        abort(500)
+    else:
+        return '', 204

--- a/src/controllers/activity_controller.py
+++ b/src/controllers/activity_controller.py
@@ -33,11 +33,9 @@ def get_activities():
 def get_activity(activity_id: int):
     """DEPRECATED. nadie me usa :("""
     app.logger.warning("Deprecation warning: get_activity. This endpoint might go away in the future.")
-    activity= ActivityRepository(app.db).find_by_id(activity_id)
+    activity = ActivityRepository(app.db).find_by_id(activity_id)
     if activity.id:
-        response = {"Deprecation warning": "This endpoint might go away in the future."}
-        response.update(activity.__dict__)
-        return jsonify(response), 200
+        return jsonify(activity), 200
     else:
         abort(404)
 
@@ -65,7 +63,7 @@ def create_activity():
         abort(500)
     else:
         if activity.id:
-            return jsonify(activity.__dict__), 200
+            return jsonify(activity), 200
         else:
             abort(500)
 
@@ -81,6 +79,7 @@ def update_activity(activity_id: int):
                         due_date=request.json.get("due_date"),
                         min_grade=request.json.get("min_grade"),
                         professor_id=claims["professor_id"])
+    app.logger.debug("activity: %s", activity)
     try:
         activity = ActivityService(app.db).update(activity)
     except ActivityOwnerError as err:
@@ -98,7 +97,10 @@ def update_activity(activity_id: int):
         if activity.id is None:
             abort(404)
         else:
-            return jsonify(activity.__dict__), 200
+            app.logger.debug("types of: due_date=%s, created_at=%s, updated_at=%s",
+                             type(activity.due_date), type(activity.created_at),
+                             type(activity.updated_at))
+            return jsonify(activity), 200
 
 @activity_routes_bp.route("/<int:activity_id>", methods=["DELETE"])
 @jwt_required()

--- a/src/models/activity.py
+++ b/src/models/activity.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 class Activity:
     def __init__(self, **kwargs):
         self.id = kwargs.get("id")
@@ -10,4 +12,5 @@ class Activity:
         self.updated_at = kwargs.get("updated_at")
 
     def __repr__(self):
-        return f"<Activity {self.name}>"
+        attrs = (f"{k}={v}" for k,v in self.__dict__.items())
+        return "{}({})".format(self.__class__.__name__, f", ".join(attrs))

--- a/src/repositories/activity_repository.py
+++ b/src/repositories/activity_repository.py
@@ -1,17 +1,19 @@
 from datetime import datetime
 
+from mysql.connector.errors import Error
+
 from src.models.activity import Activity
-from typing import Union
-from mysql.connector.errors import IntegrityError
+from src.db import Database
 
 class ActivityRepository:
-    def __init__(self, db):
+    def __init__(self, db: Database):
         self.db = db
 
     def find_all(self) -> list[dict]:
         with self.db.get_connection() as conn:
             cursor = conn.cursor(dictionary=True)
-            cursor.execute("SELECT * FROM activities")
+            # TODO: ordenar por apellido de profesor
+            cursor.execute("SELECT * FROM activities ORDER BY professor_id, created_at DESC")
             result = cursor.fetchall()
             return result
 
@@ -25,7 +27,7 @@ class ActivityRepository:
             else:
                 return Activity(id=None)
 
-    def find_by_name(self, name):
+    def find_by_name(self, name) -> list[Activity]:
         """Buscar actividades por nombre.
 
         Se utilizan los comodines %name%, con LIKE.
@@ -33,7 +35,8 @@ class ActivityRepository:
         name = f"%{name}%"
         with self.db.get_connection() as conn:
             cursor = conn.cursor(dictionary=True)
-            cursor.execute("SELECT * FROM activities WHERE name LIKE %s", (name,))
+            cursor.execute("SELECT * FROM activities WHERE name LIKE %s ORDER BY created_at DESC",
+                           (name,))
             result = cursor.fetchall()
             if result:
                 activities = []
@@ -44,15 +47,16 @@ class ActivityRepository:
             else:
                 return []
 
-    def find_by_professor(self, professor_id):
+    def find_by_professor(self, professor_id) -> list[dict]:
         """Buscar todas las actividades de un professor."""
         with self.db.get_connection() as conn:
             cursor = conn.cursor(dictionary=True)
-            cursor.execute("SELECT * FROM activities WHERE professor_id = %s", (professor_id,))
+            cursor.execute("SELECT * FROM activities WHERE professor_id = %s ORDER BY created_at DESC",
+                           (professor_id,))
             result = cursor.fetchall()
             return result
 
-    def find_by_due_date(self, due_date: datetime):
+    def find_by_due_date(self, due_date: datetime) -> list[dict]:
         """Buscar actividades por fecha de entrega.
 
         Se asume due_date del tipo datetime.datetime y al buscar
@@ -60,11 +64,12 @@ class ActivityRepository:
         """
         with self.db.get_connection() as conn:
             cursor = conn.cursor(dictionary=True)
-            cursor.execute("SELECT * FROM activities WHERE due_date = %s", (due_date.date,))
+            cursor.execute("SELECT * FROM activities WHERE due_date = %s ORDER BY created_at DESC",
+                           (due_date.date,))
             result = cursor.fetchall()
             return result
 
-    def save(self, activity: Activity):
+    def save(self, activity: Activity) -> Activity:
         with self.db.get_connection() as conn:
             cursor = conn.cursor()
             try:
@@ -75,49 +80,50 @@ class ActivityRepository:
                                        activity.min_grade,
                                        activity.professor_id,
                                        None))
-            except IntegrityError:
+            except Error:
                 conn.rollback()
                 raise
             else:
                 conn.commit()
                 activity.id = res[-1]
-                return activity
+                return self.find_by_id(activity.id)
 
-    def update(self, activity: Activity):
+    def update(self, activity: Activity) -> Activity:
         """Actualizar datos de una actividad.
 
         Por defecto no se actualiza el id del professor
         que creo la actividad originalmente.
         """
         query = """UPDATE activities
-                    SET name = %s, description = %s, due_date = %s, min_grade = %s
-                    WHERE id = %s"""
+                   SET name = %s, description = %s, due_date = %s, min_grade = %s
+                   WHERE id = %s"""
         with self.db.get_connection() as conn:
             cursor = conn.cursor()
             try:
                 cursor.execute(query, (activity.name,
-                                        activity.description,
-                                        activity.due_date,
-                                        activity.min_grade,
-                                        activity.id))
-            except IntegrityError:
+                                       activity.description,
+                                       activity.due_date,
+                                       activity.min_grade,
+                                       activity.id))
+            except Error:
                 conn.rollback()
                 raise
             else:
                 conn.commit()
+                return self.find_by_id(activity.id)
 
-    def delete(self, activity: Activity):
+    def delete(self, activity_id: int) -> None:
         """Eliminar una actividad.
 
         Asume que se pasa una actividad con un id valido.
         Aunque puede no existir.
         """
-        query = "DELETE FROM activities WHERE id = %s"
+        query = "DELETE FROM activities WHERE id = %s AND due_date > current_date()"
         with self.db.get_connection() as conn:
             cursor = conn.cursor()
             try:
-                cursor.execute(query, (activity.id,))
-            except IntegrityError:
+                cursor.execute(query, (activity_id,))
+            except Error:
                 conn.rollback()
                 raise
             else:

--- a/src/repositories/user_repository.py
+++ b/src/repositories/user_repository.py
@@ -1,10 +1,11 @@
 from src.models.user import Student, Professor
 from typing import Union
 from mysql.connector.errors import IntegrityError
+from src.db import Database
 
 
 class UserRepository:
-    def __init__(self, db):
+    def __init__(self, db: Database):
         self.db = db
 
     def get_user_by_id(self, user_id: int) -> Union[Student, Professor]:
@@ -194,3 +195,14 @@ class UserRepository:
                 student.id = res[-1]
                 student.password = None
                 return student
+
+    def get_professor_by_id(self, professor_id: int) -> dict:
+        query = "SELECT * FROM professors WHERE id = %s"
+        with self.db.get_connection() as conn:
+            cur = conn.cursor(dictionary=True)
+            cur.execute(query, (professor_id,))
+            professor_data =cur.fetchone()
+            if professor_data:
+                return Professor(**professor_data)
+            else:
+                return None

--- a/src/services/activity_service.py
+++ b/src/services/activity_service.py
@@ -12,12 +12,8 @@ class ActivityOwnerError(Exception):
 
 class ActivityService:
     def __init__(self, db):
-        try:
-            self.activity_repository = ActivityRepository(db)
-            self.user_repository = UserRepository(db)
-        except DbError as err:
-            app.logging.critical("")
-            raise
+        self.activity_repository = ActivityRepository(db)
+        self.user_repository = UserRepository(db)
 
     def get_activities(self, professor_id=None):
         """Obtiene todas las actividades, filtrando por professor_id si existe."""

--- a/src/services/activity_service.py
+++ b/src/services/activity_service.py
@@ -1,0 +1,103 @@
+from datetime import datetime
+
+from flask import current_app as app
+
+from src.models.activity import Activity
+from src.repositories.activity_repository import ActivityRepository
+from src.db import DbError
+from src.repositories.user_repository import UserRepository
+
+class ActivityOwnerError(Exception):
+    pass
+
+class ActivityService:
+    def __init__(self, db):
+        try:
+            self.activity_repository = ActivityRepository(db)
+            self.user_repository = UserRepository(db)
+        except DbError as err:
+            app.logging.critical("")
+            raise
+
+    def get_activities(self, professor_id=None):
+        """Obtiene todas las actividades, filtrando por professor_id si existe."""
+
+        if professor_id:
+            if self.user_repository.get_professor_by_id(professor_id):
+                return self.activity_repository.find_by_professor(professor_id)
+            else:
+                raise ValueError("Professor id doesn't exist.")
+        return self.activity_repository.find_all()
+
+    def create(self, activity: Activity) -> Activity:
+        if activity.name is None:
+            raise ValueError("Activity name cannot be empty.")
+        # no hay ninguna validacion para activity.description
+        if activity.due_date is None:
+            raise ValueError("Activity due_date cannot be empty.")
+        else:
+            try:
+                activity.due_date = datetime.strptime(activity.due_date, "%Y-%m-%d")
+            except ValueError:
+                raise ValueError("Activity due_date is in the wrong format.")
+            else:
+                if activity.due_date < datetime.today():
+                    raise ValueError("Activity due_date cannot be a past date.")
+        if activity.min_grade is None:
+            raise ValueError("Activity min_grade cannot be empty.")
+        else:
+            if activity.min_grade.isdecimal():
+                activity.min_grade = int(activity.min_grade)
+                if not (0 < activity.min_grade <= 10):
+                    raise ValueError("Activity min_grade not in range 1 - 10.")
+        if activity.professor_id is None: # esto no debería pasar nunca
+            app.logger.critical("activity.professor_id is None, no debería pasar nunca.")
+            raise RuntimeError("Activity professor_id cannot be empty.")
+        return self.activity_repository.save(activity)
+
+    def update(self, activity: Activity) -> Activity:
+        og_activity = self.activity_repository.find_by_id(activity.id)
+        if og_activity.id is None: # si la actividad no existe su id es None
+            return activity
+        if activity.professor_id != og_activity.professor_id:
+            raise ActivityOwnerError("Request's professor_id does not match activity's professor_id.")
+        if activity.name is None:
+            activity.name = og_activity.name
+        if activity.description is None and og_activity.description is not None:
+            activity.description = og_activity.description
+        if activity.due_date is None:
+            activity.due_date = og_activity.due_date
+        else:
+            try:
+                activity.due_date = datetime.strptime(activity.due_date, "%Y-%m-%d")
+            except ValueError:
+                raise ValueError("Activity due_date is in the wrong format.")
+            else:
+                if activity.due_date < datetime.today():
+                    raise ValueError("Activity due_date cannot be a past date.")
+        if activity.min_grade is None:
+            activity.min_grade = og_activity.min_grade
+        else:
+            if activity.min_grade.isdecimal():
+                activity.min_grade = int(activity.min_grade)
+                if not (0 < activity.min_grade <= 10):
+                    raise ValueError("Activity min_grade not in range 1 - 10.")
+            else:
+                raise ValueError("Activity min_grade must be decimal.")
+        return self.activity_repository.update(activity)
+
+    def delete (self, activity_id: int, professor_id: int):
+        """Elimina una actividad.
+
+        Solo si existe, es del professor pasado por
+        param y si no esta vencida todavia.
+        """
+        activity = self.activity_repository.find_by_id(activity_id)
+        if activity.id is None:
+            raise ValueError("Activity doesn't exist.")
+        if professor_id != activity.professor_id:
+            raise ActivityOwnerError("Request's professor_id does not match activity's professor_id.")
+        if activity.due_date <= datetime.today():
+            raise ValueError("Activity already due.")
+
+        self.activity_repository.delete(activity.id)

--- a/src/services/auth_service.py
+++ b/src/services/auth_service.py
@@ -1,13 +1,11 @@
 import json
 
 import bcrypt
-from flask import jsonify
 from flask_jwt_extended import create_access_token
+from mysql.connector.errors import IntegrityError
 
 from src.models.user import User, Student, Professor
 from src.repositories.user_repository import UserRepository
-from mysql.connector.errors import IntegrityError
-from src.db import DbError
 
 class AuthPasswordError(Exception):
     pass
@@ -15,10 +13,7 @@ class AuthPasswordError(Exception):
 
 class AuthService:
     def __init__(self, db):
-        try:
-            self.user_repository = UserRepository(db)
-        except DbError:
-            raise
+        self.user_repository = UserRepository(db)
 
     def login(self, user: User) -> tuple:
         try:


### PR DESCRIPTION
Ahora si.

En el endpoint de delete, tuve que cambiar `return None, 204` porque no le gustaba. Sí o sí debe ser un string, entonces quedó `'', 204`.
Saqué los cambios hechos a `app.py` y `db.py`, estos deberían ir en otro tipo de patch. Luego lo hago por separado.

Agregué un ActivityOwnerError para los casos en los que se intente modificar o eliminar una actividad, siendo professor logueado, pero no el creador de dica activity.